### PR TITLE
1.1.11 Repair Token Refresh & key vault integration

### DIFF
--- a/EntraAuth/EntraAuth.psd1
+++ b/EntraAuth/EntraAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'EntraAuth.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.6'
+ModuleVersion = '1.1.11'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/EntraAuth/changelog.md
+++ b/EntraAuth/changelog.md
@@ -1,6 +1,14 @@
 ﻿# Changelog
 
-## 1.0.6
+## 1.1.11 (2024-05-21)
+
++ New: Service configurations - Added configurations for Azure & AzureKeyVault.
++ Upd: Connect-EntraService - Added support for direct Key Vault integration.
++ Upd: Service configurations - Added capability to require additional parameters that modify the base Service Url.
++ Fix: Token Renewal - bad parameter ServiceUrl.
++ Fix: Asset-EntraConnection - bad error message when assertion fails.
+
+## 1.0.6 (2024-05-15)
 
 + Upd: Invoke-EntraRequest - added -NoPaging parameter to support disabling paging.
 + Upd: Invoke-EntraRequest - added -Raw parameter to support returning unprocessed results.

--- a/EntraAuth/functions/Authentication/Assert-EntraConnection.ps1
+++ b/EntraAuth/functions/Authentication/Assert-EntraConnection.ps1
@@ -45,6 +45,6 @@
 		
 		$message = "Not connected yet! Use Connect-EntraService to establish a connection to '$Service' first."
 		if ($RequiredScopes) { $message = $message + " Scopes required for this call: $($RequiredScopes -join ', ')"}
-		Invoke-TerminatingException -Cmdlet $Cmdlet -Message  -Category ConnectionError
+		Invoke-TerminatingException -Cmdlet $Cmdlet -Message $message -Category ConnectionError
 	}
 }

--- a/EntraAuth/functions/Authentication/Connect-EntraService.ps1
+++ b/EntraAuth/functions/Authentication/Connect-EntraService.ps1
@@ -70,6 +70,17 @@
 
 		Part of the Resource Owner Password Credential (ROPC) workflow.
 
+	.PARAMETER VaultName
+		Name of the Azure Key Vault from which to retrieve the certificate or client secret used for the authentication.
+		Secrets retrieved from the vault are not cached, on token expiration they will be retrieved from the Vault again.
+		In order for this flow to work, please ensure that you either have an active AzureKeyVault service connection,
+		or are connected via Connect-AzAccount.
+
+	.PARAMETER SecretName
+		Name of the secret to use from the Azure Key Vault specified through the '-VaultName' parameter.
+		In order for this flow to work, please ensure that you either have an active AzureKeyVault service connection,
+		or are connected via Connect-AzAccount.
+
 	.PARAMETER Service
 		The service to connect to.
 		Individual commands using Invoke-EntraRequest specify the service to use and thus identify the token needed.
@@ -112,6 +123,11 @@
 		PS C:\> Connect-EntraService -Service Endpoint -ClientID $clientID -TenantID $tenantID -ClientSecret $secret
 	
 		Establish a connection to Defender for Endpoint using a client secret.
+	
+	.EXAMPLE
+		PS C:\> Connect-EntraService -ClientID $clientID -TenantID $tenantID -VaultName myVault -Secretname GraphCert
+	
+		Establish a connection to the graph API, after retrieving the necessary certificate from the specified Azure Key Vault.
 #>
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
 	[CmdletBinding(DefaultParameterSetName = 'Browser')]

--- a/EntraAuth/internal/functions/authentication/Get-VaultSecret.ps1
+++ b/EntraAuth/internal/functions/authentication/Get-VaultSecret.ps1
@@ -1,0 +1,107 @@
+﻿function Get-VaultSecret {
+	<#
+	.SYNOPSIS
+		Retrieve a secret from Azure Key Vault.
+	
+	.DESCRIPTION
+		Retrieve a secret from Azure Key Vault.
+		Works for both certificates and secrets.
+
+		Requires one of ...
+		- An established connection with the AzureKeyVault service.
+		- An established AZ session via Az.Accounts with the Az.KeyVault module present.
+	
+	.PARAMETER VaultName
+		Name of the Vault to query.
+	
+	.PARAMETER SecretName
+		Name of the Secret to retrieve.
+	
+	.PARAMETER Cmdlet
+		The $PSCmdlet object of the caller, enabling errors to happen within the scope of the caller.
+		Defaults to the current command's $PSCmdlet
+	
+	.EXAMPLE
+		PS C:\> Get-VaultSecret -VaultName myvault -SecretName mysecret
+		
+		Retrieves the latest enabled version of mysecret from myvault
+	#>
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		[string]
+		$VaultName,
+		
+		[Parameter(Mandatory = $true)]
+		[string]
+		$SecretName,
+
+		$Cmdlet = $PSCmdlet
+	)
+
+	process {
+		#region Via EntraAuth
+		if (Get-EntraToken -Service AzureKeyVault) {
+			try {
+				$secretVersion = Invoke-EntraRequest -Service AzureKeyVault -Path "secrets/$SecretName/versions?api-version=7.4" -VaultName $VaultName -ErrorAction Stop | Where-Object {
+					$_.attributes.enabled
+				} | Sort-Object { $_.attributes.created } -Descending | Select-Object -First 1
+				$secretData = Invoke-EntraRequest -Service AzureKeyVault -Path "$($secretVersion.id)?api-version=7.4" -VaultName $VaultName -ErrorAction Stop
+			}
+			catch {
+				Invoke-TerminatingException -Cmdlet $Cmdlet -ErrorRecord $_ -Message "Failed to retrieve secret '$SecretName' from '$VaultName'! $_"
+			}
+
+			if ($secretVersion.contentType) {
+				$secretBytes = [convert]::FromBase64String($secretData)
+				$certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($secretBytes)
+				[PSCustomObject]@{
+					Type         = 'Certificate'
+					Certificate  = $certificate
+					ClientSecret = $null
+				}
+			}
+			else {
+				[PSCustomObject]@{
+					Type         = 'ClientSecret'
+					Certificate  = $null
+					ClientSecret = $secretData | ConvertTo-SecureString -AsPlainText -Force
+				}
+			}
+
+			return
+		}
+		#endregion Via EntraAuth
+
+		#region Via Az.KeyVault
+		if ((Get-Module Az.Accounts -ListAvailable) -and (Get-AzContext) -and (Get-Module Az.KeyVault -ListAvailable)) {
+			try { $secret = Get-AzKeyVaultSecret -VaultName $VaultName -Name $SecretName }
+			catch { Invoke-TerminatingException -Cmdlet $Cmdlet -ErrorRecord $_ -Message "Error accessing the secret '$Secretname' from Vault '$VaultName'. $_" }
+
+			$type = 'Certificate'
+			if (-not $secret.ContentType) { $type = 'ClientSecret' }
+
+			$certificate = $null
+			$clientSecret = $secret.SecretValue
+
+			if ($type -eq 'Certificate') {
+				$certString = [PSCredential]::New("irrelevant", $secret.SecretValue).GetNetworkCredential().Password
+				$bytes = [convert]::FromBase64String($certString)
+				$certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($bytes)
+				$clientSecret = $null
+			}
+			
+			[PSCustomObject]@{
+				Type         = $type
+				Certificate  = $certificate
+				ClientSecret = $clientSecret
+			}
+
+			return
+		}
+		#endregion Via Az.KeyVault
+
+		Invoke-TerminatingException -Cmdlet $Cmdlet -Message "Not connected to azure yet! Either use 'Connect-EntraService -Service AzureKeyVault' or 'Connect-AzAccount' before trying to connect via KeyVault!" -Category ConnectionError
+	}
+}

--- a/EntraAuth/internal/functions/other/Resolve-RequestUri.ps1
+++ b/EntraAuth/internal/functions/other/Resolve-RequestUri.ps1
@@ -1,0 +1,51 @@
+﻿function Resolve-RequestUri {
+	<#
+	.SYNOPSIS
+		Resolves the actual Uri used for a request in Invoke-EntraRequest.
+	
+	.DESCRIPTION
+		Resolves the actual Uri used for a request in Invoke-EntraRequest.
+		If the path provided is a full url, it will be returned as is.
+		Otherwise, any present parameters will be resolved in the base service url before merging it with the specified path.
+	
+	.PARAMETER TokenObject
+		The object representing the token used for the request.
+	
+	.PARAMETER ServiceObject
+		The service object (if any) used with the request.
+		The parameters to be inserted into the query will be read from here.
+	
+	.PARAMETER BoundParameters
+		The parameters provided to Invoke-EntraRequest.
+	
+	.EXAMPLE
+		PS C:\> Resolve-RequestUri -TokenObject $tokenObject -ServiceObject $script:_EntraEndpoints.$($tokenObject.Service) -BoundParameters $PSBoundParameters
+
+		Resolves the uri for the needed request based on token, service and parameters provided
+	#>
+	[OutputType([string])]
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		$TokenObject,
+
+		[Parameter(Mandatory = $true)]
+		[AllowNull()]
+		$ServiceObject,
+
+		[Parameter(Mandatory = $true)]
+		$BoundParameters
+	)
+	process {
+		if ($BoundParameters.Path -match '^https{0,1}://') {
+			return $BoundParameters.Path
+		}
+
+		$serviceUrlBase = $TokenObject.ServiceUrl.Trim()
+		foreach ($key in $ServiceObject.Parameters.Keys) {
+			$serviceUrlBase = $serviceUrlBase -replace "%$key%", $BoundParameters.$key
+		}
+
+		"$($serviceUrlBase.TrimEnd('/'))/$($Path.TrimStart('/'))"
+	}
+}

--- a/EntraAuth/internal/scripts/02-Services.ps1
+++ b/EntraAuth/internal/scripts/02-Services.ps1
@@ -36,3 +36,24 @@ $graphBetaCfg = @{
 	HelpUrl       = 'https://developer.microsoft.com/en-us/graph/quick-start'
 }
 Register-EntraService @graphBetaCfg
+
+$azureCfg = @{
+	Name          = 'Azure'
+	ServiceUrl    = 'https://management.azure.com'
+	Resource      = 'https://management.core.windows.net/'
+	DefaultScopes = @()
+	HelpUrl       = 'https://learn.microsoft.com/en-us/rest/api/azure/?view=rest-resources-2022-12-01'
+}
+Register-EntraService @azureCfg
+
+$azureKeyVaultCfg = @{
+	Name          = 'AzureKeyVault'
+	ServiceUrl    = 'https://%VAULTNAME%.vault.azure.net'
+	Resource      = 'https://vault.azure.net'
+	DefaultScopes = @()
+	HelpUrl       = 'https://learn.microsoft.com/en-us/rest/api/keyvault/?view=rest-keyvault-secrets-7.4'
+	Parameters    = @{
+		VaultName = 'Name of the Key Vault to execute against'
+	}
+}
+Register-EntraService @azureKeyVaultCfg


### PR DESCRIPTION
+ New: Service configurations - Added configurations for Azure & AzureKeyVault.
+ Upd: Connect-EntraService - Added support for direct Key Vault integration.
+ Upd: Service configurations - Added capability to require additional parameters that modify the base Service Url.
+ Fix: Token Renewal - bad parameter ServiceUrl.
+ Fix: Asset-EntraConnection - bad error message when assertion fails.