### PR TITLE
1.4.21

### DIFF
--- a/EntraAuth/EntraAuth.psd1
+++ b/EntraAuth/EntraAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'EntraAuth.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.19'
+ModuleVersion = '1.4.21'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/EntraAuth/changelog.md
+++ b/EntraAuth/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 1.4.21 (2024-11-26)
+
++ Upd: Added support for authenticating using an existing refresh token
++ Fix: Invoke-EntraRequest - "body not supported with this method" error when using Get requests with a body (#23)
+
 ## 1.3.19 (2024-10-13)
 
 + Upd: Invoke-EntraRequest - `-Body` parameter now supports raw string or custom objects.

--- a/EntraAuth/functions/Core/Invoke-EntraRequest.ps1
+++ b/EntraAuth/functions/Core/Invoke-EntraRequest.ps1
@@ -144,6 +144,12 @@
 				$parameters.Body = $Body | ConvertTo-Json -Compress -Depth $SerializationDepth
 			}
 		}
+		# In PS5.1, some methods cannot contain a body
+		$noBodyMethods = 'Default', 'Get', 'Head'
+		if ($PSVersionTable.PSVersion.Major -lt 6 -and $Method -in $noBodyMethods) {
+			$parameters.Remove('Body')
+		}
+		
 		$parameters.Uri += ConvertTo-QueryString -QueryHash $Query -DefaultQuery $serviceObject.Query
 
 		do {

--- a/EntraAuth/internal/classes/EntraToken.ps1
+++ b/EntraAuth/internal/classes/EntraToken.ps1
@@ -182,6 +182,9 @@
 				$result = Connect-ServiceBrowser @defaultParam -SelectAccount
 				$this.SetTokenMetadata($result)
 			}
+			Refresh {
+				Connect-ServiceRefreshToken -Token $this
+			}
 			KeyVault {
 				$secret = Get-VaultSecret -VaultName $this.VaultName -SecretName $this.SecretName
 				$result = switch ($secret.Type) {

--- a/EntraAuth/internal/functions/authentication/Connect-ServiceRefreshToken.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServiceRefreshToken.ps1
@@ -18,24 +18,68 @@
 	#>
 	[CmdletBinding()]
 	param (
-		[Parameter(Mandatory = $true)]
-		$Token
+		[Parameter(Mandatory = $true, ParameterSetName = 'Token')]
+		$Token,
+
+		[Parameter(Mandatory = $true, ParameterSetName = 'Details')]
+		[string]
+		$RefreshToken,
+
+		[Parameter(Mandatory = $true, ParameterSetName = 'Details')]
+		[string]
+		$TenantID,
+
+		[Parameter(Mandatory = $true, ParameterSetName = 'Details')]
+		[string]
+		$ClientID,
+
+		[Parameter(Mandatory = $true, ParameterSetName = 'Details')]
+		[string]
+		$Resource,
+
+		[Parameter(ParameterSetName = 'Details')]
+		[string[]]
+		$Scopes = '.default',
+
+		[Parameter(Mandatory = $true, ParameterSetName = 'Details')]
+        [string]
+		$AuthenticationUrl
 	)
 	process {
-		if (-not $Token.RefreshToken) {
-			throw "Failed to refresh token: No refresh token found!"
-		}
+		switch ($PSCmdlet.ParameterSetName) {
+			'Token' {
+				if (-not $Token.RefreshToken) {
+					throw "Failed to refresh token: No refresh token found!"
+				}
+		
+				$effectiveScopes = $Token.Scopes
+		
+				$body = @{
+					client_id = $Token.ClientID
+					scope = @($effectiveScopes).ForEach{"$($Token.Audience)/$($_)"} -join " "
+					refresh_token = $Token.RefreshToken
+					grant_type = 'refresh_token'
+				}
+				$uri = "$($Token.AuthenticationUrl)/$($Token.TenantID)/oauth2/v2.0/token"
+				$authResponse = Invoke-RestMethod -Method Post -Uri $uri -Body $body
+				$Token.SetTokenMetadata((Read-AuthResponse -AuthResponse $authResponse))
+			}
+			'Details' {
+				$effectiveScopes = foreach ($scope in $Scopes) {
+					if ($scope -like "$Resource*") { $scope }
+					else { "$Resource/$scope" }
+				}
 
-		$scopes = $Token.Scopes
-
-		$body = @{
-			client_id = $Token.ClientID
-			scope = @($scopes).ForEach{"$($Token.Audience)/$($_)"} -join " "
-			refresh_token = $Token.RefreshToken
-			grant_type = 'refresh_token'
+				$body = @{
+					client_id = $ClientID
+					scope = $effectiveScopes -join " "
+					refresh_token = $RefreshToken
+					grant_type = 'refresh_token'
+				}
+				$uri = "$($AuthenticationUrl)/$($TenantID)/oauth2/v2.0/token"
+				$authResponse = Invoke-RestMethod -Method Post -Uri $uri -Body $body
+				Read-AuthResponse -AuthResponse $authResponse
+			}
 		}
-		$uri = "$($Token.AuthenticationUrl)/$($Token.TenantID)/oauth2/v2.0/token"
-		$authResponse = Invoke-RestMethod -Method Post -Uri $uri -Body $body
-		$Token.SetTokenMetadata((Read-AuthResponse -AuthResponse $authResponse))
 	}
 }

--- a/EntraAuth/internal/functions/authentication/Connect-ServiceRefreshToken.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServiceRefreshToken.ps1
@@ -7,12 +7,32 @@
 		Connect with the refresh token provided previously.
 		Used mostly for delegate authentication flows to avoid interactivity.
 
+		Can also be resolved to from the outside, when trying to get multiple tokens with a single delegate flow.
+
 	.PARAMETER Token
 		The EntraToken object with the refresh token to use.
 		The token is then refreshed in-place with no output provided.
+
+	.PARAMETER RefreshToken
+		The RefreshToken to use for authenticating.
+
+	.PARAMETER TenantID
+		ID of the tenant to connect to.
+
+	.PARAMETER ClientID
+		ID of the application to connect as.
+
+	.PARAMETER Resource
+		Resource we want the scopes for.
+
+	.PARAMETER Scopes
+		Scopes we want to use.
+
+	.PARAMETER AuthenticationUrl
+		The url used for the authentication requests to retrieve tokens.
 	
 	.EXAMPLE
-		PS C:\> Connect-ServiceRefreshToken
+		PS C:\> Connect-ServiceRefreshToken -Token $token
 		
 		Connect with the refresh token provided previously.
 	#>


### PR DESCRIPTION
+ Upd: Added support for authenticating using an existing refresh token
+ Fix: Invoke-EntraRequest - "body not supported with this method" error when using Get requests with a body (#23)