### PR TITLE
adding tenant autodetection

### DIFF
--- a/EntraAuth/EntraAuth.psd1
+++ b/EntraAuth/EntraAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'EntraAuth.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.22'
+ModuleVersion = '1.4.23'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/EntraAuth/changelog.md
+++ b/EntraAuth/changelog.md
@@ -1,5 +1,9 @@
 ﻿# Changelog
 
+## 1.4.23 (2025-01-14)
+
++ Upd: Connect-EntraService - removed TenantID requirement for most delegate flows, defaulting the parameter to "organizations". TenantID on the managed token object is now read from the returned token.
+
 ## 1.4.22 (2024-12-04)
 
 + Upd: Connect-EntraService - added `-UseRefreshToken` parameter for delegate flows, showing the interactive prompts only if needed.

--- a/EntraAuth/functions/Authentication/Connect-EntraService.ps1
+++ b/EntraAuth/functions/Authentication/Connect-EntraService.ps1
@@ -333,7 +333,7 @@
 				$_.ClientID -eq $ClientID -and
 				(
 					$_.TenantID -eq $TenantID -or
-					$TenantID -eq 'organizations'	
+					$TenantID -eq 'organizations'
 				) -and
 				$_.RefreshToken
 			} | Sort-Object ValidUntil -Descending | Select-Object -First 1

--- a/EntraAuth/functions/Authentication/Connect-EntraService.ps1
+++ b/EntraAuth/functions/Authentication/Connect-EntraService.ps1
@@ -184,6 +184,7 @@
 		Establish a connection to the graph API, after retrieving the necessary certificate from the specified Azure Key Vault.
 #>
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseDeclaredVarsMoreThanAssignments", "")]
+	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidDefaultValueForMandatoryParameter", "")]
 	[CmdletBinding(DefaultParameterSetName = 'Browser')]
 	param (
 		[Parameter(Mandatory = $true, ParameterSetName = 'Browser')]
@@ -196,15 +197,15 @@
 		[string]
 		$ClientID,
 		
-		[Parameter(Mandatory = $true, ParameterSetName = 'Browser')]
-		[Parameter(Mandatory = $true, ParameterSetName = 'DeviceCode')]
+		[Parameter(ParameterSetName = 'Browser')]
+		[Parameter(ParameterSetName = 'DeviceCode')]
 		[Parameter(Mandatory = $true, ParameterSetName = 'Refresh')]
 		[Parameter(Mandatory = $true, ParameterSetName = 'AppCertificate')]
 		[Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
 		[Parameter(Mandatory = $true, ParameterSetName = 'UsernamePassword')]
 		[Parameter(Mandatory = $true, ParameterSetName = 'KeyVault')]
 		[string]
-		$TenantID,
+		$TenantID = 'organizations',
 		
 		[Parameter(ParameterSetName = 'Browser')]
 		[Parameter(ParameterSetName = 'DeviceCode')]
@@ -330,7 +331,10 @@
 		if ($UseRefreshToken) {
 			$availableToken = Get-EntraToken | Where-Object {
 				$_.ClientID -eq $ClientID -and
-				$_.TenantID -eq $TenantID -and
+				(
+					$_.TenantID -eq $TenantID -or
+					$TenantID -eq 'organizations'	
+				) -and
 				$_.RefreshToken
 			} | Sort-Object ValidUntil -Descending | Select-Object -First 1
 		}

--- a/EntraAuth/internal/classes/EntraToken.ps1
+++ b/EntraAuth/internal/classes/EntraToken.ps1
@@ -128,6 +128,7 @@
 		$this.Audience = $data.aud
 		$this.Issuer = $data.iss
 		$this.TokenData = $data
+		$this.TenantID = $data.tid
 	}
 
 	[hashtable]GetHeader() {

--- a/tests/general/Help.Tests.ps1
+++ b/tests/general/Help.Tests.ps1
@@ -108,11 +108,6 @@ foreach ($command in $commands) {
 					$parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
 				}
                 
-                $codeMandatory = $parameter.IsMandatory.toString()
-				It "help for $parameterName parameter in $commandName has correct Mandatory value" -TestCases @{ parameterHelp = $parameterHelp; codeMandatory = $codeMandatory } {
-					$parameterHelp.Required | Should -Be $codeMandatory
-				}
-                
                 if ($HelpTestSkipParameterType[$commandName] -contains $parameterName) { continue }
                 
                 $codeType = $parameter.ParameterType.Name


### PR DESCRIPTION
+ Upd: Connect-EntraService - removed TenantID requirement for most delegate flows, defaulting the parameter to "organizations". TenantID on the managed token object is now read from the returned token.