### PR TITLE
1.5.28

### DIFF
--- a/EntraAuth/EntraAuth.psd1
+++ b/EntraAuth/EntraAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'EntraAuth.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.23'
+ModuleVersion = '1.5.28'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -66,6 +66,7 @@ FunctionsToExport = @(
 	'Connect-EntraService'
 	'Get-EntraService'
 	'Get-EntraToken'
+	'Import-EntraToken'
 	'Invoke-EntraRequest'
 	'Register-EntraService'
 	'Set-EntraService'

--- a/EntraAuth/changelog.md
+++ b/EntraAuth/changelog.md
@@ -1,5 +1,13 @@
 ﻿# Changelog
 
+## 1.5.28 (2025-02-14)
+
++ New: Import-EntraToken - Imports a token into the local token store.
++ Upd: Connect-EntraService - added `-FallbackAzAccount` parameter to allow MSI authentication to fall back to the existing Az Session in case of trouble.
++ Upd: Connect-EntraService - enabled multiple secret names to be specified when logging in via Key Vault.
++ Upd: Token - default Query values are now copied onto the token from the service configuration.
++ Upd: Invoke-EntraRequest - uses default Query values from the token, rather than the service configuration
+
 ## 1.4.23 (2025-01-14)
 
 + Upd: Connect-EntraService - removed TenantID requirement for most delegate flows, defaulting the parameter to "organizations". TenantID on the managed token object is now read from the returned token.

--- a/EntraAuth/functions/Authentication/Import-EntraToken.ps1
+++ b/EntraAuth/functions/Authentication/Import-EntraToken.ps1
@@ -1,0 +1,82 @@
+﻿function Import-EntraToken {
+	<#
+	.SYNOPSIS
+		Imports a token into the local token store.
+	
+	.DESCRIPTION
+		Imports a token into the local token store.
+		This command is intended for use in a runspace scenario, for passing tokens from the main runspace into background environments.
+		The input-token object is cloned into a runspace-local token object and registered to its service.
+
+		After performing the conversion, it will try to renew the token object.
+	
+	.PARAMETER Token
+		The token object to import.
+		Should be a token object created by EntraAuth's Connect-EntraService command.
+		Usually returned by Get-EntraToken, after finishing the connection.
+	
+	.PARAMETER PassThru
+		Rather than registering the token into the Entra token store in memory, return it as an object.
+		Useful for ronspace-localizing a token not associated with any given service.
+	
+	.PARAMETER NoRenew
+		Do not renew the token after importing it.
+		By default, newly localized tokens will try to renew themselves, to avoid parallel use of the same access token instance.
+	
+	.EXAMPLE
+		PS C:\> Import-EntraToken -Token $using:tokens
+
+		Imports all tokens stored in $tokens of the calling runspace.
+		For use in scenarios such as background runspaces within "ForEach-Object -Parallel"
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+		[object[]]
+		$Token,
+
+		[switch]
+		$PassThru,
+
+		[switch]
+		$NoRenew
+	)
+	process {
+		foreach ($tokenObject in $Token) {
+			$newToken = [EntraToken]::new()
+			foreach ($propertyName in $newToken.PSObject.Properties.Name) {
+				if ($null -eq $tokenObject.$propertyName) { continue }
+				if ($tokenObject.$propertyName -is [hashtable]) {
+					$newToken.$propertyName = $tokenObject.$propertyName.Clone()
+				}
+				else {
+					$newToken.$propertyName = $tokenObject.$propertyName
+				}
+			}
+
+			if (
+				-not $newToken.Service -or
+				-not $newToken.AccessToken -or
+				-not $newToken.ClientID -or
+				-not $newToken.TenantID
+			) {
+				Invoke-TerminatingException -Cmdlet $PSCmdlet -Message "Invalid Input Object! An Entra token object must have a Service, AccessToken, ClientID and TenantID. Item received: $tokenObject"
+			}
+
+			#region Renew Token
+			if (
+				-not $NoRenew -and
+				(
+					$newToken.Type -notin 'DeviceCode', 'Browser' -or
+					$newToken.RefreshToken
+				)
+			) {
+				$newToken.RenewToken()
+			}
+			#endregion Renew Token
+
+			if ($PassThru) { $newToken }
+			else { $script:_EntraTokens[$newToken.Service] = $newToken }
+		}
+	}
+}

--- a/EntraAuth/functions/Core/Invoke-EntraRequest.ps1
+++ b/EntraAuth/functions/Core/Invoke-EntraRequest.ps1
@@ -76,7 +76,7 @@
 		$Header = @{},
 		
 		[ArgumentCompleter({ Get-ServiceCompletion $args })]
-		[ValidateScript({ Assert-ServiceName -Name $_ })]
+		[ValidateScript({ Assert-ServiceName -Name $_ -IncludeTokens })]
 		[string]
 		$Service = $script:_DefaultService,
 
@@ -150,7 +150,7 @@
 			$parameters.Remove('Body')
 		}
 		
-		$parameters.Uri += ConvertTo-QueryString -QueryHash $Query -DefaultQuery $serviceObject.Query
+		$parameters.Uri += ConvertTo-QueryString -QueryHash $Query -DefaultQuery $tokenObject.Query
 
 		do {
 			$parameters.Headers = $tokenObject.GetHeader() + $Header # GetHeader() automatically refreshes expried tokens

--- a/EntraAuth/internal/classes/EntraToken.ps1
+++ b/EntraAuth/internal/classes/EntraToken.ps1
@@ -18,6 +18,7 @@
 	[string]$ServiceUrl
 	[string]$AuthenticationUrl
 	[Hashtable]$Header = @{}
+	[Hashtable]$Query = @{}
 
 	[string]$IdentityID
 	[string]$IdentityType
@@ -108,6 +109,9 @@
 		$this.ShowDialog = $ShowDialog
 		$this.Type = 'AzAccount'
 	}
+	
+	# Empty Constructor for Import-EntraToken
+	EntraToken() {}
 	#endregion Constructors
 
 	[void]SetTokenMetadata([PSObject] $AuthToken) {

--- a/EntraAuth/internal/functions/authentication/Get-VaultSecret.ps1
+++ b/EntraAuth/internal/functions/authentication/Get-VaultSecret.ps1
@@ -47,6 +47,10 @@
 				$secretVersion = Invoke-EntraRequest -Service AzureKeyVault -Path "secrets/$SecretName/versions" -VaultName $VaultName -ErrorAction Stop | Where-Object {
 					$_.attributes.enabled
 				} | Sort-Object { $_.attributes.created } -Descending | Select-Object -First 1
+
+				if (-not $secretVersion) {
+					Invoke-TerminatingException -Cmdlet $Cmdlet -ErrorRecord $_ -Message "Secret '$SecretName' does not exist in vault '$VaultName'! $_"
+				}
 				$secretData = Invoke-EntraRequest -Service AzureKeyVault -Path $secretVersion.id -VaultName $VaultName -ErrorAction Stop
 			}
 			catch {

--- a/EntraAuth/internal/functions/other/Invoke-TerminatingException.ps1
+++ b/EntraAuth/internal/functions/other/Invoke-TerminatingException.ps1
@@ -1,6 +1,5 @@
-﻿function Invoke-TerminatingException
-{
-<#
+﻿function Invoke-TerminatingException {
+	<#
 	.SYNOPSIS
 		Throw a terminating exception in the context of the caller.
 	
@@ -47,7 +46,7 @@
 		$ErrorRecord
 	)
 	
-	process{
+	process {
 		if ($ErrorRecord -and -not $Message) {
 			$Cmdlet.ThrowTerminatingError($ErrorRecord)
 		}
@@ -62,7 +61,10 @@
 		
 		
 		if ($Exception) { $newException = $Exception.GetType()::new($Message, $Exception) }
-		elseif ($ErrorRecord) { $newException = $ErrorRecord.Exception.GetType()::new($Message, $ErrorRecord.Exception) }
+		elseif ($ErrorRecord) {
+			try { $newException = $ErrorRecord.Exception.GetType()::new($Message, $ErrorRecord.Exception) }
+			catch { $newException = [System.Exception]::new($Message, $ErrorRecord.Exception) }
+		}
 		else { $newException = $exceptionType::new($Message) }
 		$record = [System.Management.Automation.ErrorRecord]::new($newException, (Get-PSCallStack)[1].FunctionName, $Category, $Target)
 		$Cmdlet.ThrowTerminatingError($record)

--- a/EntraAuth/internal/functions/ux/Assert-ServiceName.ps1
+++ b/EntraAuth/internal/functions/ux/Assert-ServiceName.ps1
@@ -9,6 +9,10 @@
 	
 	.PARAMETER Name
 		The name of the service to verify.
+
+	.PARAMETER IncludeTokens
+		Also include registered token's services in the assertion.
+		By default, the assertion will only verify the existence of registered services.
 	
 	.EXAMPLE
 		PS C:\> Assert-ServiceName -Name $_
@@ -20,12 +24,16 @@
 	param (
 		[Parameter(Mandatory = $true)]
 		[AllowEmptyString()]
-		[AllowNUll()]
+		[AllowNull()]
 		[string]
-		$Name
+		$Name,
+
+		[switch]
+		$IncludeTokens
 	)
 	process {
 		if ($script:_EntraEndpoints.Keys -contains $Name) { return $true }
+		if ($IncludeTokens -and $script:_EntraTokens.Keys -contains $Name) { return $true }
 
 		$serviceNames = $script:_EntraEndpoints.Keys -join ', '
 		Write-Warning "Invalid service name: '$Name'. Legal service names: $serviceNames"


### PR DESCRIPTION
+ New: Import-EntraToken - Imports a token into the local token store.
+ Upd: Connect-EntraService - added `-FallbackAzAccount` parameter to allow MSI authentication to fall back to the existing Az Session in case of trouble.
+ Upd: Connect-EntraService - enabled multiple secret names to be specified when logging in via Key Vault.
+ Upd: Token - default Query values are now copied onto the token from the service configuration.
+ Upd: Invoke-EntraRequest - uses default Query values from the token, rather than the service configuration