### PR TITLE
1.5.30

### DIFF
--- a/EntraAuth/EntraAuth.psd1
+++ b/EntraAuth/EntraAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'EntraAuth.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.5.28'
+ModuleVersion = '1.5.30'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -99,7 +99,7 @@ PrivateData = @{
         Tags = @('EntraID', 'Token')
 
         # A URL to the license for this module.
-        # LicenseUri = ''
+        LicenseUri = 'https://github.com/FriedrichWeinmann/EntraAuth/blob/master/LICENSE'
 
         # A URL to the main website for this project.
         ProjectUri = 'https://github.com/FriedrichWeinmann/EntraAuth'

--- a/EntraAuth/changelog.md
+++ b/EntraAuth/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 1.5.30 (2025-03-05)
+
++ Upd: Connect-EntraService - now accepts "Graph" or "Azure" as ClientID, resolving the respective first party App IDs.
++ Fix: Connect-EntraService - fails to find a certificate by name, when the cert store contains only a single certificate
+
 ## 1.5.28 (2025-02-14)
 
 + New: Import-EntraToken - Imports a token into the local token store.

--- a/EntraAuth/functions/Authentication/Connect-EntraService.ps1
+++ b/EntraAuth/functions/Authentication/Connect-EntraService.ps1
@@ -9,6 +9,10 @@
 	
 	.PARAMETER ClientID
 		ID of the registered/enterprise application used for authentication.
+
+		Supports providing special labels as "ID":
+		+ Azure: Resolves to the actual ID of the first party app used by Connect-AzAccount
+		+ Graph: Resolves to the actual ID of the first party app used by Connect-MgGraph
 	
 	.PARAMETER TenantID
 		The ID of the tenant/directory to connect to.
@@ -199,6 +203,7 @@
 		[Parameter(Mandatory = $true, ParameterSetName = 'AppSecret')]
 		[Parameter(Mandatory = $true, ParameterSetName = 'UsernamePassword')]
 		[Parameter(Mandatory = $true, ParameterSetName = 'KeyVault')]
+		[ArgumentCompleter({ 'Graph', 'Azure' })]
 		[string]
 		$ClientID,
 		
@@ -333,6 +338,11 @@
 	begin {
 		$doRegister = $PSBoundParameters.Keys -notcontains 'Resource'
 		$doPassThru = $PassThru -or $Resource
+
+		switch ($ClientID) {
+			'Graph' { $ClientID = '14d82eec-204b-4c2f-b7e8-296a70dab67e' }
+			'Azure' { $ClientID = '1950a258-227b-4e31-a9cf-717495945fc2' }
+		}
 	}
 	process {
 		#region UseRereshToken

--- a/EntraAuth/internal/functions/other/Resolve-Certificate.ps1
+++ b/EntraAuth/internal/functions/other/Resolve-Certificate.ps1
@@ -38,10 +38,10 @@
 		Invoke-TerminatingException -Cmdlet $PSCmdlet -Message "Unable to find certificate with thumbprint '$($BoundParameters.CertificateThumbprint)'"
 	}
 	if ($BoundParameters.CertificateName) {
-		if ($certificate = (Get-ChildItem 'Cert:\CurrentUser\My\').Where{ $_.Subject -eq $BoundParameters.CertificateName -and $_.HasPrivateKey }) {
+		if ($certificate = @(Get-ChildItem 'Cert:\CurrentUser\My\').Where{ $_.Subject -eq $BoundParameters.CertificateName -and $_.HasPrivateKey }) {
 			return $certificate | Sort-Object NotAfter -Descending | Select-Object -First 1
 		}
-		if ($certificate = (Get-ChildItem 'Cert:\LocalMachine\My\').Where{ $_.Subject -eq $BoundParameters.CertificateName -and $_.HasPrivateKey }) {
+		if ($certificate = @(Get-ChildItem 'Cert:\LocalMachine\My\').Where{ $_.Subject -eq $BoundParameters.CertificateName -and $_.HasPrivateKey }) {
 			return $certificate | Sort-Object NotAfter -Descending | Select-Object -First 1
 		}
 		Invoke-TerminatingException -Cmdlet $PSCmdlet -Message "Unable to find certificate with subject '$($BoundParameters.CertificateName)'"


### PR DESCRIPTION
+ Upd: Connect-EntraService - now accepts "Graph" or "Azure" as ClientID, resolving the respective first party App IDs.
+ Fix: Connect-EntraService - fails to find a certificate by name, when the cert store contains only a single certificate