### PR TITLE
Remove MiniGraph dependency and update examples for some cmdlets and update of aud url

### DIFF
--- a/EntraAuth/changelog.md
+++ b/EntraAuth/changelog.md
@@ -1,5 +1,16 @@
 ﻿# Changelog
 
+## 1.7.40 (2025-06-30)
++ Upd: Register-EntraService - Extra examples on registering EntraServices
++ Upd: Connect-ServiceBrowser - Removed dependency to MiniGraph
++ Fix: Connect-ServiceCertificate - Updated audiance to reflect the updated url endpoint descriped in docs
++ Upd: Connect-ServiceClientSecret - Added -Resource and -AuthenticationUrl to the Example for clarity
++ Upd: Connect-ServiceDeviceCode - Added -Resource and -AuthenticationUrl to the Example for clarity 
++ Upd: Connect-ServiceDeviceCode - Modified Description to reflect it using the Device Code workflow and not just saying Browser authentication.
++ Upd: Connect-ServicePassword - Added -Resource and -AuthenticationUrl to the Example for clarity
++ Upd: Connect-ServiceRefreshToken - Added example of using the ParameterSet Details instead of only having the example for Token ParameterSet
++ Upd: nothing-to-see-here.txt - Copied from MiniGraph repo to remove dependency to a remote repo that is not EntraAuth
+
 ## 1.7.39 (2025-04-15)
 
 + Upd: New-EntraFilterBuilder - Now supports both AND and OR logic.

--- a/EntraAuth/functions/Authentication/Register-EntraService.ps1
+++ b/EntraAuth/functions/Authentication/Register-EntraService.ps1
@@ -63,8 +63,24 @@
 	
 	.EXAMPLE
 		PS C:\> Register-EntraService -Name Endpoint -ServiceUrl 'https://api.securitycenter.microsoft.com/api' -Resource 'https://api.securitycenter.microsoft.com'
-		
+
 		Registers the defender for endpoint API as a service.
+
+    .EXAMPLE
+        PS C:\> Register-EntraService -Name 'PowerBI' -ServiceUrl 'https://api.powerbi.com/v1.0/myorg' -Resource 'https://analysis.windows.net/powerbi/api' -DefaultScopes @('Dataset.Read.All', 'Report.Read.All') -Header @{ 'Accept' = 'application/json' }
+
+        Registers Power BI REST API service with common read scopes and required headers.
+
+    .EXAMPLE
+        PS C:\> Register-EntraService -Name 'SharePointOnline' -ServiceUrl 'https://%TENANT%.sharepoint.com/_api' -Resource 'https://%TENANT%.sharepoint.com' -Parameters @{ Tenant = 'SharePoint tenant name (e.g., contoso)' } -DefaultScopes @('Sites.Read.All') -Query @{ '$format' = 'json' }
+
+        Registers SharePoint Online REST API with dynamic tenant URL, requiring a tenant parameter and automatically formatting responses as JSON.
+
+    .EXAMPLE
+        PS C:\> Register-EntraService -Name 'CustomCRM' -ServiceUrl 'https://crm.contoso.com/api/v2' -Resource 'api://contoso-crm-app' -NoRefresh -RawOnly -Header @{ 'X-API-Version' = '2.0'; 'Accept' = 'application/json' }
+
+        Registers a custom CRM API that doesn't support refresh tokens and requires raw response handling with custom API versioning headers.
+
 	#>
 	[CmdletBinding()]
 	param (

--- a/EntraAuth/internal/functions/authentication/Connect-ServiceBrowser.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServiceBrowser.ps1
@@ -129,7 +129,7 @@
 		$uriFinal = $uri + ($paramStrings -join '&')
 		Write-Verbose "Authorize Uri: $uriFinal"
 
-		$redirectTo = 'https://raw.githubusercontent.com/FriedrichWeinmann/MiniGraph/master/nothing-to-see-here.txt'
+		$redirectTo = 'https://raw.githubusercontent.com/FriedrichWeinmann/EntraAuth/master/nothing-to-see-here.txt'
 		if ((Get-Random -Minimum 10 -Maximum 99) -eq 66) {
 			$redirectTo = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
 		}

--- a/EntraAuth/internal/functions/authentication/Connect-ServiceCertificate.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServiceCertificate.ps1
@@ -60,7 +60,7 @@
     }
     $encodedHeader = $jwtHeader | ConvertTo-Json | ConvertTo-Base64
     $claims = @{
-        aud = "$AuthenticationUrl/$TenantID/v2.0"
+        aud = "$AuthenticationUrl/$TenantID/oauth2/v2.0/token"
         exp = ((Get-Date).AddMinutes(5).ToUniversalTime() - (Get-Date -Date '1970-01-01')).TotalSeconds -as [int]
         iss = $ClientID
         jti = "$(New-Guid)"

--- a/EntraAuth/internal/functions/authentication/Connect-ServiceClientSecret.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServiceClientSecret.ps1
@@ -22,7 +22,7 @@
 		The url used for the authentication requests to retrieve tokens.
 	
 	.EXAMPLE
-		PS C:\> Connect-ServiceClientSecret -ClientID '<ClientID>' -TenantID '<TenantID>' -ClientSecret $secret
+		PS C:\> Connect-ServiceClientSecret -ClientID '<ClientID>' -TenantID '<TenantID>' -ClientSecret $secret -Resource '<Resource>' -AuthenticationUrl 'https://login.microsoftonline.com'
 	
 		Connects to the specified tenant using the specified client and secret.
 #>

--- a/EntraAuth/internal/functions/authentication/Connect-ServiceDeviceCode.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServiceDeviceCode.ps1
@@ -28,9 +28,9 @@
 		The url used for the authentication requests to retrieve tokens.
 	
 	.EXAMPLE
-		PS C:\> Connect-ServiceDeviceCode -ServiceUrl $url -ClientID '<ClientID>' -TenantID '<TenantID>'
+		PS C:\> Connect-ServiceDeviceCode -Resource 'https://graph.microsoft.com' -ClientID '<ClientID>' -TenantID '<TenantID>' -AuthenticationUrl 'https://login.microsoftonline.com'
 	
-		Connects to the specified tenant using the specified client, prompting the user to authorize via Browser.
+		Connects to the specified tenant using the specified client, prompting the user to authorize via Device Code workflow.
 	#>
 	[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
 	[CmdletBinding()]

--- a/EntraAuth/internal/functions/authentication/Connect-ServicePassword.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServicePassword.ps1
@@ -28,7 +28,7 @@
 		The url used for the authentication requests to retrieve tokens.
     
     .EXAMPLE
-        PS C:\> Connect-ServicePassword -Credential max@contoso.com -ClientID $client -TenantID $tenant -Scopes 'user.read','user.readbasic.all'
+        PS C:\> Connect-ServicePassword -Credential max@contoso.com -ClientID $client -TenantID $tenant -Scopes 'user.read','user.readbasic.all' -Resource 'https://graph.microsoft.com' -AuthenticationUrl 'https://login.microsoftonline.com'
         
         Connect as max@contoso.com with the rights to read user information.
     #>

--- a/EntraAuth/internal/functions/authentication/Connect-ServiceRefreshToken.ps1
+++ b/EntraAuth/internal/functions/authentication/Connect-ServiceRefreshToken.ps1
@@ -35,6 +35,12 @@
 		PS C:\> Connect-ServiceRefreshToken -Token $token
 		
 		Connect with the refresh token provided previously.
+
+	.EXAMPLE
+        PS C:\> Connect-ServiceRefreshToken -RefreshToken $refreshToken -TenantID '<TenantID>' -ClientID '<ClientID>' -Resource 'https://graph.microsoft.com' -Scopes @('User.Read', 'Mail.Read') -AuthenticationUrl 'https://login.microsoftonline.com'
+        
+        Connect using specific refresh token details with custom scopes for Microsoft Graph.
+		
 	#>
 	[CmdletBinding()]
 	param (

--- a/nothing-to-see-here.txt
+++ b/nothing-to-see-here.txt
@@ -1,0 +1,1 @@
+Authentication flow completed, you can close the tab now.


### PR DESCRIPTION
Eliminate the dependency on MiniGraph to prevent potential issues in the remote repository. 

Register-EntraService
- Added some extra examples in Register-EntraService to try and give more clarity to the command and its options.

Connect-ServiceBrowser
- Removed the dependenci to MiniGraph from 

Connect-ServiceCertificate
- Updated audiance to reflect the updated url endpoint descriped in docs

Connect-ServiceClientSecret
- Added -Resource and -AuthenticationUrl to the Example for clarity

Connect-ServiceDeviceCode
- Added -Resource and -AuthenticationUrl to the Example for clarity
- Modified Description to reflect it using the Device Code workflow and not just saying Browser authentication.

Connect-ServicePassword
- Added -Resource and -AuthenticationUrl to the Example for clarity

Connect-ServiceRefreshToken
- Added example of using the ParameterSet Details instead of only having the example for Token ParameterSet

nothing-to-see-here.txt
- Copied from MiniGraph repo to remove dependency to a remote repo that is not EntraAuth

Test run from pester.ps1 results:
Starting Tests
Importing Module
Creating test result folder
Modules imported, proceeding with general tests
  Executing FileIntegrity.Tests.ps1
  Executing Help.Tests.ps1
  Executing Manifest.Tests.ps1
  Executing PSScriptAnalyzer.Tests.ps1
Proceeding with individual tests
  Executing New-EntraFilterBuilder.tests.ps1
All 3592 tests executed without a single failure!
