### PR TITLE
1.8.52

### DIFF
--- a/EntraAuth/EntraAuth.psd1
+++ b/EntraAuth/EntraAuth.psd1
@@ -4,7 +4,7 @@
 RootModule = 'EntraAuth.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.8.50'
+ModuleVersion = '1.8.52'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/EntraAuth/changelog.md
+++ b/EntraAuth/changelog.md
@@ -1,5 +1,10 @@
 ﻿# Changelog
 
+## 1.8.52 (2026-02-20)
+
++ Fix: Connect-EntraService - Federated Credentials fail to refresh the token correctly
++ Fix: Filter Builder - custom filter conditions might not be evaluated correctly, if they contain multiple clauses.
+
 ## 1.8.50 (2025-07-21)
 
 + Fix: Federation Provider EntraMSI - unable to resolve Federation Provider

--- a/EntraAuth/functions/Authentication/Connect-EntraService.ps1
+++ b/EntraAuth/functions/Authentication/Connect-EntraService.ps1
@@ -696,7 +696,6 @@
 					}
 
 					$token = [EntraToken]::new($serviceName, $ClientID, $TenantID, $provider, $effectiveServiceUrl, $authUrl)
-					$token = [EntraToken]::new($serviceName, $effectiveServiceUrl, $IdentityID, $IdentityType)
 					$token.SetTokenMetadata($result)
 
 					Write-Verbose "[$serviceName] Connected via Federated Credential ($($token.Scopes -join ', '))"

--- a/EntraAuth/internal/classes/03-FilterBuilder.ps1
+++ b/EntraAuth/internal/classes/03-FilterBuilder.ps1
@@ -87,7 +87,7 @@ It translates into an OData all(...) logic with the "ne" operator applied.
 			}
 			# Custom Filters
 			if ($entry -is [string]) {
-				$entry
+				'(' + $entry + ')'
 				continue
 			}
 

--- a/tests/functions/New-EntraFilterBuilder.tests.ps1
+++ b/tests/functions/New-EntraFilterBuilder.tests.ps1
@@ -55,6 +55,6 @@
 
 		$filterBuilder.Add('(abc eq 42)')
 
-		$filterBuilder.Get() | Should -Be "enabled eq True and (name eq 'Fred' or name eq 'Max') and (abc eq 42)"
+		$filterBuilder.Get() | Should -Be "enabled eq True and (name eq 'Fred' or name eq 'Max') and ((abc eq 42))"
 	}
 }


### PR DESCRIPTION
+ Fix: Connect-EntraService - Federated Credentials fail to refresh the token correctly
+ Fix: Filter Builder - custom filter conditions might not be evaluated correctly, if they contain multiple clauses.